### PR TITLE
Hotfix/fix insert into post

### DIFF
--- a/tinymce/kaltura_tinymce.js
+++ b/tinymce/kaltura_tinymce.js
@@ -16,7 +16,8 @@
 			});
 
 			var onBeforeSetContentDelegate = Kaltura.Delegate.create(this, this._onBeforeSetContent);
-			ed.onBeforeSetContent.add(onBeforeSetContentDelegate);
+			ed.on('BeforeSetContent', onBeforeSetContentDelegate);
+
 
 			var onGetContentDelegate = Kaltura.Delegate.create(this, this._onGetContent);
 			ed.onGetContent.add(onGetContentDelegate);
@@ -56,11 +57,11 @@
 
 		_tagEnd: ['/]', ']'],
 
-		_onBeforeSetContent: function (ed, obj) {
-			if (!obj.content)
+		_onBeforeSetContent: function (ed) {
+			if (!ed.content)
 				return;
 
-			var contentData = obj.content;
+			var contentData = ed.content;
 			var startPos = 0;
 
 			while ((startPos = contentData.indexOf(this._tagStart, startPos)) != -1) {
@@ -145,7 +146,7 @@
 				contentData += contentDataEnd;
 			}
 
-			obj.content = contentData;
+			ed.content = contentData;
 		},
 
 		_onGetContent: function (ed, obj) {

--- a/view/library/send-to-editor.php
+++ b/view/library/send-to-editor.php
@@ -1,58 +1,65 @@
 <?php KalturaHelpers::protectView( $this ); ?>
 <?php if ( $this->uiConfId ): ?>
 	<script type="text/javascript">
-		var playerWidth = <?php echo wp_json_encode($this->playerWidth); ?>;
-		var playerHeight = <?php echo wp_json_encode($this->playerHeight); ?>;
-		var uiConfId = <?php echo wp_json_encode($this->uiConfId); ?>;
-		var entryId = <?php echo wp_json_encode($this->entryId); ?>;
-		var isResponsive = <?php echo wp_json_encode($this->isResponsive); ?>;
-		var hoveringControls = <?php echo wp_json_encode($this->hoveringControls); ?>;
+		jQuery('document').ready(function(){
+			var playerWidth = <?php echo wp_json_encode($this->playerWidth); ?>;
+			var playerHeight = <?php echo wp_json_encode($this->playerHeight); ?>;
+			var uiConfId = <?php echo wp_json_encode($this->uiConfId); ?>;
+			var entryId = <?php echo wp_json_encode($this->entryId); ?>;
+			var isResponsive = <?php echo wp_json_encode($this->isResponsive); ?>;
+			var hoveringControls = <?php echo wp_json_encode($this->hoveringControls); ?>;
+	
+			var htmlArray = [];
+			htmlArray.push('[');
+			htmlArray.push('kaltura-widget ');
+			htmlArray.push('uiconfid="' + uiConfId + '" ');
+			htmlArray.push('entryid="' + entryId + '" ');
+			htmlArray.push('width="' + playerWidth + '" ');
+			htmlArray.push('height="' + playerHeight + '" ');
+			htmlArray.push('responsive="' + isResponsive + '" ');
+			htmlArray.push('hoveringControls="' + hoveringControls + '" ');
+			htmlArray.push('/]');
+			htmlArray.push('\n');
+	
+	
+			var html = htmlArray.join('');
+	
+			// lets make it safe
+			try {
+				var topWindow = Kaltura.getTopWindow();
+	
+				if (topWindow.tinyMCE && topWindow.tinyMCE.get('content') && !topWindow.tinyMCE.get('content').isHidden()) {
+					var ed = topWindow.tinyMCE.activeEditor;
+					if (topWindow.tinyMCE.isIE && ed.windowManager.insertimagebookmark)
+						ed.selection.moveToBookmark(ed.windowManager.insertimagebookmark);
 
-		var htmlArray = [];
-		htmlArray.push('[');
-		htmlArray.push('kaltura-widget ');
-		htmlArray.push('uiconfid="' + uiConfId + '" ');
-		htmlArray.push('entryid="' + entryId + '" ');
-		htmlArray.push('width="' + playerWidth + '" ');
-		htmlArray.push('height="' + playerHeight + '" ');
-		htmlArray.push('responsive="' + isResponsive + '" ');
-		htmlArray.push('hoveringControls="' + hoveringControls + '" ');
-		htmlArray.push('/]');
-		htmlArray.push('\n');
-
-
-		var html = htmlArray.join('');
-
-		// lets make it safe
-		try {
-			var topWindow = Kaltura.getTopWindow();
-
-			if (topWindow.tinyMCE && topWindow.tinyMCE.get('content') && !topWindow.tinyMCE.get('content').isHidden()) {
-				var ed = topWindow.tinyMCE.activeEditor;
-				if (topWindow.tinyMCE.isIE && ed.windowManager.insertimagebookmark)
-					ed.selection.moveToBookmark(ed.windowManager.insertimagebookmark);
-
-				topWindow.tinyMCE.execCommand('mceInsertRawHTML', false, html);
-			}
-			else {
-				if (topWindow.edInsertContent) {
-					topWindow.edInsertContent(topWindow.document.getElementById('content'), html);
+					ed.insertContent(html);
 				}
 				else {
-					var content = topWindow.jQuery('#content');
-					content.val(content.val() + html);
+					if (topWindow.edInsertContent) {
+						topWindow.edInsertContent(topWindow.document.getElementById('content'), html);
+					}
+					else {
+						var content = topWindow.jQuery('#content');
+						content.val(content.val() + html);
+					}
 				}
+	
+				<?php if (count($this->nextEntryIds) > 0): ?>
+				window.location.href = <?php echo wp_json_encode( esc_js( KalturaHelpers::generateTabUrl(array('tab' => 'kaltura_upload', 'kaction' => 'sendtoeditor', 'firstedit' => 'true', 'entryIds' => $this->nextEntryIds) ) ) ); ?>;
+				<?php else: ?>
+				setTimeout(topWindow.tb_remove(), 0);
+				<?php endif; ?>
+			}
+			catch (e) {
+				var displayEditTable = true;
 			}
 
-			<?php if (count($this->nextEntryIds) > 0): ?>
-			window.location.href = <?php echo wp_json_encode( esc_js( KalturaHelpers::generateTabUrl(array('tab' => 'kaltura_upload', 'kaction' => 'sendtoeditor', 'firstedit' => 'true', 'entryIds' => $this->nextEntryIds) ) ) ); ?>;
-			<?php else: ?>
-			setTimeout('topWindow.tb_remove()', 0);
-			<?php endif; ?>
-		}
-		catch (e) {
-			var displayEditTable = true;
-		}
+			if (displayEditTable) {
+				jQuery("table").show();
+				jQuery("#txtCode").val(html);
+			}
+		});
 	</script>
 	<div id="send-to-editor" class="kaltura-tab">
 		<form method="post" class="kaltura-form">
@@ -73,12 +80,6 @@
 			</table>
 		</form>
 	</div>
-	<script>
-		if (displayEditTable) {
-			jQuery("table").show();
-			jQuery("#txtCode").val(html);
-		}
-	</script>
 <?php else: ?>
 	<?php
 	$flashVarsStr = KalturaHelpers::flashVarsToString( $this->flashVars );


### PR DESCRIPTION
This pull request fixes the issue where inserting a video into a post doesn't work anymore.

This issue is partly happening because the tinymce version was updated in wp 4.8
https://codex.wordpress.org/Version_4.8

There is some other weird stuff that needed to be fixed and I am not really clear on why it was setup like that, for example:
- the quotes around `'topWindow.tb_remove()'` and 
- the fact that the code expected the `Kaltura` object to be available during the execution of the inline code even though kaltura.js is only loaded in the footer